### PR TITLE
limit the length of topic

### DIFF
--- a/meetings/management/commands/sendmessages.py
+++ b/meetings/management/commands/sendmessages.py
@@ -40,6 +40,8 @@ class Command(BaseCommand):
             sys.exit(1)
 
     def get_start_template(self, openid, meeting_id, topic, time):
+        if len(topic) > 20:
+            topic = topic[:20]
         content = {
             "touser": openid,
             "template_id": "2xSske0tAcOVKNG9EpBjlb1I-cjPWSZrpwPDTgqAmWI",

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -259,6 +259,8 @@ class MeetingDelView(GenericAPIView, DestroyModelMixin):
         return JsonResponse({"code": 204, "message": "Delete successfully."})
 
     def get_remove_template(self, openid, topic, time, mid):
+        if len(topic) > 20:
+            topic = topic[:20]
         content = {
             "touser": openid,
             "template_id": "UpxRbZf8Z9QiEPlZeRCgp_MKvvqHlo6tcToY8fToK50",


### PR DESCRIPTION
在小程序订阅消息参数值内容限制说明中，thing.DATA的长度限制为20个字符，当传入参数过长时，会报47003的错误。详见
https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/subscribe-message/subscribeMessage.send.html 中订阅消息参数值内容限制说明。因此当topic长度大于20字符时，截取前20个字符传入模板，能做到不影响小程序上topic的显示，又能给创建者和收藏者发送推送消息。