### PR TITLE
remove the prefix of route

### DIFF
--- a/mindspore_meetings/urls.py
+++ b/mindspore_meetings/urls.py
@@ -34,5 +34,5 @@ schema_view = get_schema_view(openapi.Info(
 urlpatterns = [
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0),name='schema-redoc'),
-    path('mindspore/', include('meetings.urls')),
+    path('', include('meetings.urls')),
 ]


### PR DESCRIPTION
Remove the prefix of route when separated from other servers because it's no longer meaningful