### PR TITLE
limit tzlocal<3.0 to avoid dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ Serializer==0.2.1
 simplejson==3.17.0
 six==1.13.0
 sqlparse==0.3.0
+tzlocal==2.1
 uritemplate==3.0.0
 urllib3==1.25.7
 Werkzeug==1.0.1


### PR DESCRIPTION
In past builds, tzlocal was built as verision 2.1 but the last was 3.0 which may lead dependency conflict. So limit the version of tzlocal.