### PR TITLE
extend fields for sponsors list and update interfaces, add collection id

### DIFF
--- a/meetings/serializers.py
+++ b/meetings/serializers.py
@@ -245,13 +245,13 @@ class AllMeetingsSerializer(ModelSerializer):
 class SponsorSerializer(ModelSerializer):
     class Meta:
         model = User
-        fields = ['id', 'nickname', 'avatar', 'gitee_name', 'enterprise']
+        fields = ['id', 'nickname', 'avatar', 'gitee_name', 'enterprise', 'telephone', 'email']
 
 
 class SponsorInfoSerializer(ModelSerializer):
     class Meta:
         model = User
-        fields = ['id', 'gitee_name', 'enterprise']
+        fields = ['id', 'gitee_name', 'enterprise', 'telephone', 'email']
 
 
 class ActivitySerializer(ModelSerializer):

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -609,8 +609,12 @@ class CollectView(GenericAPIView, ListModelMixin, CreateModelMixin):
     def post(self, request, *args, **kwargs):
         user_id = self.request.user.id
         meeting_id = self.request.data['meeting']
-        Collect.objects.create(meeting_id=meeting_id, user_id=user_id)
-        resp = {'code': 201, 'msg': 'collect successfully'}
+        if not meeting_id:
+            return JsonResponse({'code': 400, 'msg': 'meeting不能为空'})
+        if not Collect.objects.filter(meeting_id=meeting_id, user_id=user_id):
+            Collect.objects.create(meeting_id=meeting_id, user_id=user_id)
+        collection_id = Collect.objects.get(meeting_id=meeting_id, user_id=user_id).id
+        resp = {'code': 201, 'msg': 'collect successfully', 'collection_id': collection_id}
         return JsonResponse(resp)
 
     def get_queryset(self):


### PR DESCRIPTION
1. extend `telephone` and `email` fields for showing sponsors and updating sponsor info
2. return collection_id after collecting a meeting successfully to satisfy the collection status change