### PR TITLE
use MeetingsListSerializer instead of serializer what shows every field

### DIFF
--- a/meetings/views.py
+++ b/meetings/views.py
@@ -530,7 +530,7 @@ class CancelMeetingView(GenericAPIView, UpdateModelMixin):
 
 class MeetingDetailView(GenericAPIView, RetrieveModelMixin):
     """会议详情"""
-    serializer_class = MeetingDetailSerializer
+    serializer_class = MeetingsListSerializer
     queryset = Meeting.objects.filter(is_delete=0)
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Repalce MeetingDetailSerializer with MeetingsListSerializer instead of showing useless fields.