### PR TITLE
fix issue that cc cannot attach calendari automatically

### DIFF
--- a/meetings/send_email.py
+++ b/meetings/send_email.py
@@ -96,7 +96,7 @@ def sendmail(topic, date, start, end, join_url, sig_name, toaddrs, etherpad,
     cal.add('method', 'REQUEST')
 
     event = icalendar.Event()
-    event.add('attendee', toaddrs_string)
+    event.add('attendee', ','.join(sorted(list(set(toaddrs_list)))))
     event.add('organizer', 'public@opengauss.org')
     event.add('summary', topic)
     event.add('dtstart', dt_start)


### PR DESCRIPTION
Although the sending list adds the list by rule, the attendee of  the calendar cannot be added. Change the scope so that new recipients can also receive the calendar that is displayed normally.