### PR TITLE
calendar optimization

### DIFF
--- a/meetings/utils/send_cancel_email.py
+++ b/meetings/utils/send_cancel_email.py
@@ -1,0 +1,96 @@
+import datetime
+import icalendar
+import logging
+import pytz
+import re
+import smtplib
+import uuid
+from django.conf import settings
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from meetings.models import Meeting
+
+logger = logging.getLogger('log')
+
+
+def sendmail(mid):
+    meeting = Meeting.objects.get(mid=mid)
+    date = meeting.date
+    start = meeting.start
+    end = meeting.end
+    toaddrs = meeting.emaillist
+    sponsor = meeting.sponsor
+    topic = '[Cancel] ' + meeting.topic
+    sig_name = meeting.group_name
+    platform = meeting.mplatform
+    platform = platform.replace('zoom', 'Zoom').replace('welink', 'WeLink')
+    start_time = ' '.join([date, start])
+    toaddrs = toaddrs.replace(' ', '').replace('，', ',').replace(';', ',').replace('；', ',')
+    toaddrs_list = toaddrs.split(',')
+    error_addrs = []
+    for addr in toaddrs_list:
+        if not re.match(r'^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$', addr):
+            error_addrs.append(addr)
+            toaddrs_list.remove(addr)
+    toaddrs_string = ','.join(toaddrs_list)
+    toaddrs_list.extend(['community@openeuler.org', 'dev@openeuler.org'])
+    toaddrs_list = sorted(list(set(toaddrs_list)))
+
+    # 构造邮件
+    msg = MIMEMultipart()
+
+    # 添加邮件主体
+    body_of_email = None
+    with open('templates/template_cancel_meeting.txt', 'r', encoding='utf-8') as fp:
+        body = fp.read()
+        body_of_email = body.replace('{{platform}}', platform). \
+                replace('{{start_time}}', start_time). \
+                replace('{{sig_name}}', sig_name)
+    content = MIMEText(body_of_email, 'plain', 'utf-8')
+    msg.attach(content)
+
+    # 取消日历
+    dt_start = (datetime.datetime.strptime(date + ' ' + start, '%Y-%m-%d %H:%M') - datetime.timedelta(hours=8)).replace(tzinfo=pytz.utc)
+    dt_end = (datetime.datetime.strptime(date + ' ' + end, '%Y-%m-%d %H:%M') - datetime.timedelta(hours=8)).replace(tzinfo=pytz.utc)
+
+    cal = icalendar.Calendar()
+    cal.add('prodid', '-//openeuler conference calendar')
+    cal.add('version', '2.0')
+    cal.add('method', 'CANCEL')
+
+    event = icalendar.Event()
+    event.add('attendee', ','.join(sorted(list(set(toaddrs_list)))))
+    event.add('summary', topic)
+    event.add('dtstart', dt_start)
+    event.add('dtend', dt_end)
+    event.add('dtstamp', dt_start)
+    event.add('uid', platform + mid)
+    event.add('sequence', 1)
+
+    cal.add_component(event)
+
+    part = MIMEBase('text', 'calendar', method='CANCEL')
+    part.set_payload(cal.to_ical())
+    encoders.encode_base64(part)
+    part.add_header('Content-class', 'urn:content-classes:calendarmessage')
+
+    msg.attach(part)
+
+    # 完善邮件信息
+    msg['Subject'] = topic
+    msg['From'] = 'openEuler conference<public@openeuler.org>'
+    msg['To'] = toaddrs_string
+
+    # 登录服务器发送邮件
+    try:
+        gmail_username = settings.GMAIL_USERNAME
+        server = smtplib.SMTP(settings.SMTP_SERVER_HOST, settings.SMTP_SERVER_PORT)
+        server.sendmail(gmail_username, toaddrs_list, msg.as_string())
+        logger.info('email string: {}'.format(toaddrs))
+        logger.info('error addrs: {}'.format(error_addrs))
+        logger.info('email sent: {}'.format(toaddrs_string))
+        server.quit()
+    except smtplib.SMTPException as e:
+        logger.error(e)

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -260,6 +260,11 @@ class MeetingDelView(GenericAPIView, DestroyModelMixin):
         meeting_id = meeting.id
         mid = meeting.mid
         logger.info('{} has canceled the meeting which mid was {}'.format(request.user.gitee_name, mid))
+
+        # 发送删除通知邮件
+        from meetings.utils.send_cancel_email import sendmail
+        sendmail(mid)
+
         # 发送会议取消通知
         collections = Collect.objects.filter(meeting_id=meeting_id)
         if collections:
@@ -511,8 +516,7 @@ class MeetingsView(GenericAPIView, CreateModelMixin):
         host_id = content['host_id']
         timezone = content['timezone'] if 'timezone' in content else 'Asia/Shanghai'
         # 发送email
-        p1 = Process(target=sendmail, args=(topic, date, start, end, join_url, sig_name, emaillist,
-            platform.replace('zoom', 'Zoom').replace('welink', 'WeLink'), etherpad, summary, record))
+        p1 = Process(target=sendmail, args=(mid, record))
         p1.start()
 
         # 数据库生成数据

--- a/templates/template_cancel_meeting.txt
+++ b/templates/template_cancel_meeting.txt
@@ -1,0 +1,1 @@
+Sorry! The {{platform}} meeting will be held at {{start_time}} scheduled by openEuler {{sig_name}} SIG has been cancelled.


### PR DESCRIPTION
1. 优化meetings.send_email.sendmail的入参
2. 拓宽calendar的attendee的范围，防止attendee为空，生成 not supported calendar message.ics
3. 同一个会议固定uid，避免在日历上多次加载
4. 提醒时间恢复为默认的会议开始前15分钟
5. 新增取消会议发送邮件通知
6. 邮箱正则匹配调整，支持前缀包含'+', '.'