### PR TITLE
unify mail sending list

### DIFF
--- a/meetings/send_email.py
+++ b/meetings/send_email.py
@@ -56,6 +56,7 @@ def sendmail(mid, topic, record=None, enclosure_paths=None):
         for k, v in maillists.items():
             if v not in toaddrs_list:
                 toaddrs_list.append(v)
+    toaddrs_list = sorted(list(set(toaddrs_list)))
     logger.info('toaddrs_list: {}'.format(toaddrs_list))
 
     # 构造邮件


### PR DESCRIPTION
预定openGauss会议时系统会默认发给sig组对应的邮件列表，在取消会议时邮件收件人也应与预定的保持一致