### PR TITLE
upgrade restframework to fix security vulnerability

### DIFF
--- a/community_meetings/settings.py
+++ b/community_meetings/settings.py
@@ -79,7 +79,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'meetings.apps.MeetingsConfig',
     'rest_framework',
-    'drf_yasg',
     'corsheaders',
     'rest_framework.authtoken',
     'django_filters'

--- a/community_meetings/urls.py
+++ b/community_meetings/urls.py
@@ -15,25 +15,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
-from rest_framework import permissions
-
-schema_view = get_schema_view(openapi.Info(
-    title="zoom_meetings",
-    default_version='v1',
-    description="The APIs are made for community meetings.",
-    terms_of_service="https://www.google.com/policies/terms/",
-    contact=openapi.Contact(email="contact@openeuler.org"),
-    license=openapi.License(name="BSD License"),
-),
-    public=True,
-    permission_classes=(permissions.AllowAny,),
-)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('meetings.urls')),
-    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0),name='schema-redoc')
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ click==7.1.2
 coreapi==2.3.3
 coreschema==0.0.4
 cryptography==2.8
-Django==2.1.7
+Django==2.2
 django-ckeditor==5.8.0
 django-cors-headers==3.2.0
 django-filter==2.2.0
 django-js-asset==1.2.2
 django-simpleui==3.9
-djangorestframework==3.11.0
+djangorestframework==3.13.1
 djangorestframework-jwt==1.11.0
 djangorestframework-simplejwt==4.4.0
 drf-yasg==1.17.0


### PR DESCRIPTION
1. 升级djangorestframework的版本，将jQuery版本升至3.5.1
2. 处理依赖，将Django版本升至2.2
3. 考虑到drf_yasg作为接口调试工具，在生产环境无实际意义，且升级djangorestframework后drf_yasg会报导包错误，故将其移除