### PR TITLE
declare the version of mysqlclient

### DIFF
--- a/meetings/__init__.py
+++ b/meetings/__init__.py
@@ -1,3 +1,4 @@
 import pymysql
 
+pymysql.version_info=(1, 4, 6, "final", 0)
 pymysql.install_as_MySQLdb()


### PR DESCRIPTION
通过在meetings/__init__.py中声明pymysql的版本为1.4.6，解决升级Django版本后mysqlclient版本异常的报错