### PR TITLE
correct the page to generate a sign code

### DIFF
--- a/meetings/utils/gene_sign_code.py
+++ b/meetings/utils/gene_sign_code.py
@@ -30,7 +30,7 @@ def gene_code_img(appid, secret, activity_id):
     url = 'https://api.weixin.qq.com/wxa/getwxacodeunlimit?access_token={}'.format(wx_token)
     data = {
         "scene": activity_id,
-        "page": "package-events/events/sign"
+        "page": "package-events/events/sign-success"
     }
     res = requests.post(url, data=json.dumps(data))
     if res.status_code != 200:


### PR DESCRIPTION
修复之前遗留的问题，该问题会导致生成的活动签到二维码无法使用