### PR TITLE
show users' nickname, avatar and openid to frontend

### DIFF
--- a/meetings/serializers.py
+++ b/meetings/serializers.py
@@ -204,7 +204,7 @@ class UserGroupSerializer(ModelSerializer):
 class UserInfoSerializer(ModelSerializer):
     class Meta:
         model = User
-        fields = ['level', 'gitee_name', 'activity_level']
+        fields = ['level', 'gitee_name', 'activity_level', 'nickname', 'avatar', 'openid']
 
 
 class GroupUserSerializer(ModelSerializer):


### PR DESCRIPTION
自2022年10月25日后，前端通过wx.getUserInfo无法再获取到真实的用户昵称和头像信息，需调整策略由后端保存、维护用户的昵称、头像等信息，本次改动仅扩展 userinfo/<int:pk>/ 接口的字段，使前端在用户登录后能获取到用户昵称、头像以及openid