### PR TITLE
update base image and satisfy requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openeuler/openeuler:21.03
+FROM openeuler/openeuler:22.03
 
 MAINTAINER TommyLike<tommylikehu@gmail.com>
 
-RUN yum update && \
+RUN yum update -y && \
     yum install -y vim wget git xz tar make automake autoconf libtool gcc gcc-c++ kernel-devel libmaxminddb-devel pcre-devel openssl openssl-devel tzdata \
         readline-devel libffi-devel python3-devel mariadb-devel python3-pip net-tools.x86_64 iputils
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-js-asset==1.2.2
 django-simpleui==3.9
 djangorestframework==3.11.0
 djangorestframework-jwt==1.11.0
-djangorestframework-simplejwt==4.4.0
+djangorestframework-simplejwt==4.5.0
 drf-yasg==1.17.0
 esdk-obs-python==3.20.11
 Flask==1.1.2
@@ -32,7 +32,7 @@ Markdown==3.1.1
 MarkupSafe==1.1.1
 mysqlclient==1.4.6
 packaging==19.2
-Pillow==6.2.1
+Pillow==9.4.0
 pycparser==2.19
 pycrypto==2.6.1
 pycryptodomex==3.9.4


### PR DESCRIPTION
由于openeuler-21.03已归档，导致当前基础镜像不可用，将其切换至22.03并修复依赖安装问题