### PR TITLE
The metadata no longer stores participant information

### DIFF
--- a/meetings/management/commands/handle_recordings.py
+++ b/meetings/management/commands/handle_recordings.py
@@ -171,7 +171,7 @@ def download_upload_recordings(start, end, zoom_download_url, mid, total_size, v
                 "record_end": end,
                 "download_url": download_url,
                 "total_size": download_file_size,
-                "attenders": attenders
+                "attenders": []
             }
             # 上传视频
             try:
@@ -374,7 +374,7 @@ def download_upload_welink_recordings(start, end, mid, filename, object_key, end
         "record_end": end,
         "download_url": download_url,
         "total_size": download_file_size,
-        "attenders": attenders
+        "attenders": []
     }
     try:
         # 断点续传上传文件


### PR DESCRIPTION
鉴于OBS对象元数据中的attenders使用率低、服务已提供查询参会者接口、attenders字段数据可能导致请求头超出限制等因素，OBS对象元数据不再存储参会者真实数据