### PR TITLE
update base image version from 21.03 to 22.03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM openeuler/openeuler:21.03
+FROM openeuler/openeuler:22.03
 
 MAINTAINER TommyLike<tommylikehu@gmail.com>
 
-RUN yum update && \
-    yum install -y vim wget git xz tar make automake autoconf libtool gcc gcc-c++ kernel-devel libmaxminddb-devel pcre-devel openssl openssl-devel tzdata \
-        readline-devel libffi-devel python3-devel mariadb-devel python3-pip net-tools.x86_64 iputils
+RUN yum install -y vim wget git xz tar make automake autoconf libtool gcc gcc-c++ kernel-devel libmaxminddb-devel pcre-devel openssl openssl-devel tzdata \
+readline-devel libffi-devel python3-devel mariadb-devel python3-pip net-tools.x86_64 iputils
 
 RUN pip3 install uwsgi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-js-asset==1.2.2
 django-simpleui==3.9
 djangorestframework==3.13.1
 djangorestframework-jwt==1.11.0
-djangorestframework-simplejwt==4.4.0
+djangorestframework-simplejwt==4.5.0
 drf-yasg==1.17.0
 esdk-obs-python==3.20.11
 Flask==1.1.2
@@ -32,7 +32,7 @@ Markdown==3.1.1
 MarkupSafe==1.1.1
 mysqlclient==1.4.6
 packaging==19.2
-Pillow==6.2.1
+Pillow==9.5.0
 pycparser==2.19
 pycrypto==2.6.1
 pycryptodomex==3.9.4


### PR DESCRIPTION
由于openeuler/openeuler:21.03不再维护，将基础镜像升级为较稳定的openeuler/openeuler:22.03，并处理相应的包版本冲突