### PR TITLE
remove XFrameOptionsMiddleware

### DIFF
--- a/opengauss_meetings/settings.py
+++ b/opengauss_meetings/settings.py
@@ -89,7 +89,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
 ROOT_URLCONF = 'opengauss_meetings.urls'


### PR DESCRIPTION
移除XFrameOptionsMiddleware中间件，该中间件的作用是给response添加header "X-Frame-Options"， 但目前前端已统一配置，需要后端移除该header避免重复