### PR TITLE
patch for mysqlclient version

### DIFF
--- a/meetings/__init__.py
+++ b/meetings/__init__.py
@@ -1,3 +1,4 @@
 import pymysql
 
+pymysql.version_info=(1, 4, 6, "final", 0)
 pymysql.install_as_MySQLdb()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ icalendar==4.0.9
 lxml==4.9.1
 mysqlclient==1.4.6
 PyMySQL==0.9.3
+pycryptodome==3.10.1
 pytz==2019.3
 PyYAML==5.4
 requests==2.31.0


### PR DESCRIPTION
1. Django版本从2.2更新至2.2.28后，会出现mysqlclient版本被识别为PyMySQL版本的问题，需声明版本信息
2. 由于PyCrypto存在未修复的漏洞，使用pycryptodome替代PyCrypto