### PR TITLE
redirect by language

### DIFF
--- a/meetings/views.py
+++ b/meetings/views.py
@@ -44,9 +44,12 @@ class GiteeAuthView(GenericAPIView, ListModelMixin):
 class LoginView(GenericAPIView):
     def post(self, request, *args, **kwargs):
         code = self.request.data.get('code')
+        language = self.request.data.get('language')
         client_id = settings.GITEE_OAUTH_CLIENT_ID
         client_secret = settings.GITEE_OAUTH_CLIENT_SECRET
         redirect_uri = settings.GITEE_OAUTH_REDIRECT
+        if language in ['zh', 'en']:
+            redirect_uri = redirect_uri + '/{}/'.format(language)
         r = requests.post('{}?grant_type=authorization_code&code={}&client_id={}&redirect_uri={}&client_secret={}'.
                           format(settings.GITEE_OAUTH_URL, code, client_id, redirect_uri, client_secret))
         if r.status_code != 200:


### PR DESCRIPTION
由于openGauss官网前端做了中英文两版，为解决在英文版登录后回调到中文版的问题，需要额外添加中英文官网两个回调地址（已在第三方应用添加），允许前端传入language字段，使Gitee Oauth2全流程的重定向地址保持一致