### PR TITLE
download the first piece of welink recordings

### DIFF
--- a/app_meeting_server/utils/handle_recordings.py
+++ b/app_meeting_server/utils/handle_recordings.py
@@ -324,8 +324,8 @@ def get_welink_recordings_download_url_and_download(meeting, recordings):
             if record_url['fileType'].lower() in ['hd', 'aux']:
                 waiting_download_recordings.append(record_url)
     target_filename = get_video_path(mid)
-    token = waiting_download_recordings[0]['token']
-    download_url = waiting_download_recordings[0]['url']
+    token = waiting_download_recordings[-1]['token']
+    download_url = waiting_download_recordings[-1]['url']
     downloadHWCloudRecording(token, target_filename, download_url)
     return target_filename
 


### PR DESCRIPTION
![image](https://github.com/opensourceways/app-meeting-server/assets/69004854/999014ec-4e27-426d-8fe8-c8ba4bed19ab)
如图，当welink会议的录像时间超过3小时，录像会按每3小时分片

![image](https://github.com/opensourceways/app-meeting-server/assets/69004854/c5253406-749e-47ad-aaf3-3f08c00a0177)
在通过confUUID查询welink录像的下载链接时，无法清晰地了解哪条对应与上图的分片对应，通过多次查询下载后，确认查询结果是按视频的生成时间逆序排序，即查询结果的最后一项对应录像的第一片切片，即需要下载的片段